### PR TITLE
Fix main class in assembly manifest

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -190,7 +190,7 @@
                     </descriptorRefs>
                     <archive>
                         <manifest>
-                            <mainClass>com.anaplan.client</mainClass>
+                            <mainClass>com.anaplan.client.Program</mainClass>
                         </manifest>
                     </archive>
                 </configuration>


### PR DESCRIPTION
You cannot run the program as a jar file because the main class was not specified correctly.